### PR TITLE
Added Project Config support for Entry Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.2 - 2019-09-06
+### Added
+- Added Project Config support for Entry Types
+
 ## 1.2.1 - 2019-04-18
 ### Fixed
 - Updated field to extend Entries class fixes #9 h/t @tinchalamo

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "extra": {
         "name": "Entries Subset",
         "handle": "entriessubset",
-        "schemaVersion": "1.1.0",
+        "schemaVersion": "1.1.1",
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/nfourtythree/craft3-entriessubset/master/CHANGELOG.md",

--- a/src/fields/EntriesSubset.php
+++ b/src/fields/EntriesSubset.php
@@ -16,8 +16,10 @@ use nfourtythree\entriessubset\services\EntriesSubsetService;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\db\Table;
 use craft\elements\Entry;
 use craft\fields\BaseRelationField;
+use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\fields\Entries;
 
@@ -123,7 +125,9 @@ class EntriesSubsetField extends Entries
         $entryTypes = $settings[ 'entryTypes' ];
 
         if ($entryTypes and is_array( $entryTypes ) and !empty( $entryTypes ) ) {
-          foreach( $entryTypes as $typeId ) {
+          foreach( $entryTypes as $typeUid ) {
+            $typeId = Db::idByUid(Table::ENTRYTYPES, $typeUid);
+
             if ( is_numeric( $typeId ) ) {
               $entryType = Craft::$app->sections->getEntryTypeById( $typeId );
 

--- a/src/migrations/m190906_102859_entry_type_id_to_uid.php
+++ b/src/migrations/m190906_102859_entry_type_id_to_uid.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace nfourtythree\entriessubset\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+use craft\helpers\Json;
+use craft\services\Fields;
+use nfourtythree\entriessubset\fields\EntriesSubsetField;
+
+/**
+ * m190906_102859_entry_type_id_to_uid migration.
+ */
+class m190906_102859_entry_type_id_to_uid extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $fields = (new Query())
+                    ->select(['id', 'uid', 'settings'])
+                    ->from([Table::FIELDS])
+                    ->where(['type' => EntriesSubsetField::class])
+                    ->all();
+
+        $entryTypeIds = [];
+
+        foreach ($fields as $field) {
+            if ($field['settings']) {
+                $settings = Json::decodeIfJson($field['settings']) ?: [];
+            } else {
+                $settings = [];
+            }
+
+            if (!empty($settings['entryTypes'])) {
+                $entryTypeIds = array_merge($entryTypeIds, $settings['entryTypes']);
+            }
+        }
+
+        $entryTypes = (new Query())
+                    ->select(['id', 'uid'])
+                    ->from([Table::ENTRYTYPES])
+                    ->where(['id' => $entryTypeIds])
+                    ->pairs();
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $projectConfig->muteEvents = true;
+
+        foreach ($fields as $field) {
+            if ($field['settings']) {
+                $settings = Json::decodeIfJson($field['settings']) ?: [];
+            } else {
+                $settings = [];
+            }
+
+            if (array_key_exists('entryTypes', $settings)) {
+                foreach ($settings['entryTypes'] as $key => $entryTypeId) {
+                    $settings['entryTypes'][$key] = $entryTypes[$entryTypeId] ?? null;
+                }
+            }
+
+            $projectConfig->set(Fields::CONFIG_FIELDS_KEY.'.'.$field['uid'].'.settings', $settings);
+
+            $this->update(Table::FIELDS, ['settings' => Json::encode($settings)], ['id' => $field['id']], [], false);
+        }
+
+        $projectConfig->muteEvents = false;
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m190906_102859_entry_type_id_to_uid cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/services/EntriesSubsetService.php
+++ b/src/services/EntriesSubsetService.php
@@ -53,7 +53,7 @@ class EntriesSubsetService extends Component
       if ( !isset( $entryTypeOptions[ $type->section->handle ] ) ) {
         $entryTypeOptions[ $type->section->handle ] = [];
       }
-      $entryTypeOptions[ $type->section->handle ][] = [ 'label' => $type->name, 'value' => $type->id ];
+      $entryTypeOptions[ $type->section->handle ][] = [ 'label' => $type->name, 'value' => $type->uid ];
     }
 
     return $entryTypeOptions;


### PR DESCRIPTION
This uses UID's to identify Entry Types in stead of ID's. Includes a migration to convert existing installations.